### PR TITLE
Update gdal-sys, update flake inputs and remove legacy GDAL flake hack.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "clap 2.34.0",
@@ -95,6 +95,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
 name = "bumpalo"
@@ -169,7 +175,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
@@ -182,7 +188,7 @@ version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -459,11 +465,11 @@ checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "gdal"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01d034014ff4d9f29ea3bf5bde5d191d98a154bc3accebde7c8c00341c9b98a"
+checksum = "b7691fc763e24396e3e0a7853573273cf2fc786798bf624db3162f3174536521"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.1",
  "chrono",
  "gdal-sys",
  "geo-types",
@@ -476,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "gdal-sys"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc578b8a84a9c950dfc110ef134f592181db19745b4ef46bf92039adf0af2dad"
+checksum = "b1e84be6573eab61cd33c64c99dc3af0cdf1116b9343239637202db203742afd"
 dependencies = [
  "libc",
  "pkg-config",
@@ -868,7 +874,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9668c493289156ed0dce9472ea33ab7a6f6dfe4565a8433bd103995f8053b467"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "ndarray",
  "netcdf-sys",
@@ -1108,7 +1114,7 @@ version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "flate2",
  "miniz_oxide",
@@ -1253,7 +1259,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1315,7 +1321,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ image = "0.24.5"  # Write images
 smartcore = "0.3.0"  # (Linear) regression packages
 noisy_float = "0.2.0"  # For inputs to ndarray-stats 
 rayon = "1.6.0"  # For parallelization of functions
-gdal = {version = "0.14.0", features = ["ndarray"]}  # For reading DEMs
+gdal = {version = "0.15.0", features = ["ndarray"]}  # For reading DEMs
 netcdf = {version = "0.7.0", features = ["ndarray", "static"]}
 proj = {version="0.27.0", features =  ["pkg_config"]}
 clap = { version = "4.0.29", features = ["derive"] }

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669969257,
-        "narHash": "sha256-mOS13sK3v+kfgP+1Mh56ohiG8uVhLHAo7m/q9kqAehc=",
+        "lastModified": 1685931219,
+        "narHash": "sha256-8EWeOZ6LKQfgAjB/USffUSELPRjw88A+xTcXnOUvO5M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b72b8b94cf0c012b0252a9100a636cad69696666",
+        "rev": "7409480d5c8584a1a83c422530419efe4afb0d19",
         "type": "github"
       },
       "original": {
@@ -31,27 +34,25 @@
         "type": "github"
       }
     },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1670009241,
-        "narHash": "sha256-MwpkQIvxgF0EWf0h9SQ1V2D1ZaPhelwZsc86uS3YXxo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5d7d1d5f742e6bb57dd2e3d7b433fb4010c7af22",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-2205": "nixpkgs-2205"
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,20 +3,17 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    # 22.05 is used for GDAL 3.5 (see more in 'shell.nix')
-    nixpkgs-2205.url = "github:NixOS/nixpkgs/nixos-22.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
   
-  outputs = {self, nixpkgs, flake-utils, nixpkgs-2205}: 
+  outputs = {self, nixpkgs, flake-utils}: 
     flake-utils.lib.eachDefaultSystem 
       (system: 
         let 
           pkgs = nixpkgs.legacyPackages.${system}; 
-          old-pkgs = nixpkgs-2205.legacyPackages.${system};
         in 
         {
-          devShells.default = import ./shell.nix {inherit pkgs; gdal=old-pkgs.gdal;};
+          devShells.default = import ./shell.nix {inherit pkgs;};
         }
       
       );

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,11 @@
 { pkgs ? import <nixpkgs> {}, gdal ? null }:
 
 let 
-  # The rust gdal system is a bit hard to compile without precompiled headers.
-  # So the minimum supported gdal version is currently 3.5 (2022-11-03)
+  # The rust gdal system is a bit hard to compile without precompiled bindings.
+  # Sometimes the unstable version of GDAL is updated faster than the precompiled bindings are in gdal-sys.
+  # Therefore, it may be necessary to provide an older GDAL as an argument. This "hack" is kept here in case
+  # it becomes needed in the future.
   my-gdal = if gdal != null then gdal else pkgs.gdal;
-
 in
 
 pkgs.mkShell {


### PR DESCRIPTION
Resolves #17.

gdal-sys 1.15 now has GDAL 3.6 and 3.7 bindings, so the old "fetch GDAL 3.4 instead" hack in the flake is not needed.