### PR TITLE
Add flake package (for installing)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,37 +1,35 @@
 { pkgs ? import <nixpkgs> { }, gdal ? null }:
-
 let
   # The rust gdal system is a bit hard to compile without precompiled bindings.
   # Sometimes the unstable version of GDAL is updated faster than the precompiled bindings are in gdal-sys.
   # Therefore, it may be necessary to provide an older GDAL as an argument. This "hack" is kept here in case
   # it becomes needed in the future.
   my-gdal = if gdal != null then gdal else pkgs.gdal;
+  manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
 
-in pkgs.mkShell {
+in pkgs.rustPlatform.buildRustPackage rec {
 
-  buildInputs = with pkgs; [
+  pname = manifest.name;
+  version = manifest.version;
+
+  cargoLock.lockFile = ./Cargo.lock;
+  nativeBuildInputs = with pkgs; [
     cargo # Manage rust projects`
-    cargo-tarpaulin # Get test coverage statistics
     rustc # Compile rust
     pkg-config # Needed to install gdal-sys
     cmake
     gnumake
-    proj
-    proj.dev
-    libclang
     clang
-    my-gdal
-    rustfmt
-
+    zlib
   ];
+  buildInputs = with pkgs; [ proj proj.dev libclang my-gdal ];
+  # libz-sys fails when compiling, so testing is disabled for now
+  doCheck = false;
+  src = pkgs.lib.cleanSource ./.;
   LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
   PKG_CONFIG_PATH =
     "${pkgs.gdal}/lib/pkgconfig/:${pkgs.proj.dev}/lib/pkgconfig";
   BINDGEN_EXTRA_CLANG_ARGS =
     "-I ${pkgs.proj.dev}/include -I ${pkgs.clang}/resource-root/include -I ${pkgs.gcc}/include";
 
-  shellHook = ''
-    ${pkgs.zsh}/bin/zsh
-    alias rsgpr="$(pwd)/target/debug/rsgpr";
-  '';
 }

--- a/default.nix
+++ b/default.nix
@@ -23,9 +23,13 @@ in pkgs.rustPlatform.buildRustPackage rec {
     zlib
   ];
   buildInputs = with pkgs; [ proj proj.dev libclang my-gdal ];
+
   # libz-sys fails when compiling, so testing is disabled for now
   doCheck = false;
+
   src = pkgs.lib.cleanSource ./.;
+
+  # Environment variables that are needed to compile
   LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
   PKG_CONFIG_PATH =
     "${pkgs.gdal}/lib/pkgconfig/:${pkgs.proj.dev}/lib/pkgconfig";

--- a/flake.nix
+++ b/flake.nix
@@ -5,16 +5,17 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
-  
-  outputs = {self, nixpkgs, flake-utils}: 
-    flake-utils.lib.eachDefaultSystem 
-      (system: 
-        let 
-          pkgs = nixpkgs.legacyPackages.${system}; 
-        in 
-        {
-          devShells.default = import ./shell.nix {inherit pkgs;};
-        }
-      
-      );
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShells.default = import ./shell.nix { inherit pkgs; };
+        packages = rec {
+          rsgpr = import ./default.nix { inherit pkgs; };
+          default = rsgpr;
+        };
+      }
+
+    );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,34 +1,19 @@
 { pkgs ? import <nixpkgs> { }, gdal ? null }:
 
 let
-  # The rust gdal system is a bit hard to compile without precompiled bindings.
-  # Sometimes the unstable version of GDAL is updated faster than the precompiled bindings are in gdal-sys.
-  # Therefore, it may be necessary to provide an older GDAL as an argument. This "hack" is kept here in case
-  # it becomes needed in the future.
-  my-gdal = if gdal != null then gdal else pkgs.gdal;
+  package = import ./default.nix {inherit pkgs gdal;};
 
 in pkgs.mkShell {
 
-  buildInputs = with pkgs; [
-    cargo # Manage rust projects`
-    cargo-tarpaulin # Get test coverage statistics
-    rustc # Compile rust
-    pkg-config # Needed to install gdal-sys
-    cmake
-    gnumake
-    proj
-    proj.dev
-    libclang
-    clang
-    my-gdal
-    rustfmt
+  inputsFrom = [package];
 
+  buildInputs = with pkgs; [
+    cargo-tarpaulin # Get test coverage statistics
+    rustfmt
   ];
-  LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
-  PKG_CONFIG_PATH =
-    "${pkgs.gdal}/lib/pkgconfig/:${pkgs.proj.dev}/lib/pkgconfig";
-  BINDGEN_EXTRA_CLANG_ARGS =
-    "-I ${pkgs.proj.dev}/include -I ${pkgs.clang}/resource-root/include -I ${pkgs.gcc}/include";
+  LIBCLANG_PATH = package.LIBCLANG_PATH;
+  PKG_CONFIG_PATH = package.PKG_CONFIG_PATH;
+  BINDGEN_EXTRA_CLANG_ARGS = package.BINDGEN_EXTRA_CLANG_ARGS;
 
   shellHook = ''
     ${pkgs.zsh}/bin/zsh


### PR DESCRIPTION
This allows the possibility to install rsgpr from the flake and be used in a regular cli fashion. 

See #16 for the rationale.