### PR TITLE
Switch interpolate function for equidistant traces and correct_antenna_separation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_float_eq"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cea652ffbedecf29e9cd41bb4c066881057a42c0c119040f022802b26853e77"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +390,18 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "enterpolation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fadf5c8cbf7c6765ff05ccbd8811cd7bc3a763e4671755204552bf8740d042a"
+dependencies = [
+ "assert_float_eq",
+ "num-traits",
+ "serde",
+ "topology-traits",
+]
 
 [[package]]
 name = "env_logger"
@@ -1080,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -1340,6 +1358,7 @@ version = "0.1.1"
 dependencies = [
  "chrono",
  "clap 4.3.2",
+ "enterpolation",
  "gdal",
  "glob",
  "image",
@@ -1552,6 +1571,15 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "topology-traits"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0c8dab428531e30115d3bfd6e3092b55256a4a7b4f87cb3abe37a000b1f4032"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ clap = { version = "4.3.2", features = ["derive"] }
 glob = "0.3.1"
 parse_duration = "2.1.1"
 num = "0.4.0"
+# num-traits = "0.2.18"
+enterpolation = "0.2"
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ clap = { version = "4.3.2", features = ["derive"] }
 glob = "0.3.1"
 parse_duration = "2.1.1"
 num = "0.4.0"
-# num-traits = "0.2.18"
 enterpolation = "0.2"
 
 [dev-dependencies]

--- a/src/io.rs
+++ b/src/io.rs
@@ -301,7 +301,7 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
         let mut data2 = file.add_variable::<f32>("data_topographically_corrected", &["y2", "x"])?;
         data2.put_values(
             &topo_data.iter().map(|v| v.to_owned()).collect::<Vec<f32>>(),
-            [height, gpr.width()],
+            ..,
         )?;
 
         // The default coordinates are distance for x and return time for y

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -2,7 +2,7 @@ use core::ops::{Add, Div, Mul, Sub};
 use enterpolation::Generator;
 use ndarray::{Array1, Array2, ArrayView1};
 use ndarray_stats::QuantileExt;
-use num::{Float, Zero};
+use num::Float;
 use rayon::prelude::*;
 /// Miscellaneous functions that are used in other parts of the program
 use std::str::FromStr;
@@ -61,28 +61,6 @@ pub fn interpolate_between_known<
 ) -> T {
     (known_xy0.1 * (known_xy1.0 - x) + known_xy1.1 * (x - known_xy0.0))
         / (known_xy1.0 - known_xy0.0)
-}
-
-fn interpolate<T: Float + Copy + Sub<Output = T> + std::fmt::Display>(
-    x_new: T,
-    x_old_0: T,
-    x_old_1: T,
-    y_old_0: T,
-    y_old_1: T,
-) -> T {
-    let res = if (!y_old_0.is_finite()) & (!y_old_1.is_finite()) {
-        T::nan()
-    } else {
-        if !y_old_0.is_finite() {
-            y_old_1
-        } else if !y_old_1.is_finite() {
-            y_old_0
-        } else {
-            y_old_0 + (x_new - x_old_0) * (y_old_1 - y_old_0) / (x_old_1 - x_old_0)
-        }
-    };
-    println!("x=[{x_old_0}, {x_old_1}], y=[{y_old_0}, {y_old_1}] => [{x_new}, {res}]");
-    res
 }
 
 fn interpolate_vec<T: Float + Copy + Sub<Output = T> + std::fmt::Debug>(
@@ -408,6 +386,7 @@ impl<F: Float + std::fmt::Display + std::iter::Sum + Send + Sync + std::fmt::Deb
         self._resample(&self.x_values, &self.target_x_values, y_values)
     }
 
+    /*
     pub fn resample_along_axis(&self, data: &Array2<F>, axis: Axis2D) -> Array2<F> {
         let nd_axis = match axis {
             Axis2D::Row => ndarray::Axis(0),
@@ -439,6 +418,7 @@ impl<F: Float + std::fmt::Display + std::iter::Sum + Send + Sync + std::fmt::Deb
         data2.slice_axis_inplace(nd_axis, slice);
         data2
     }
+    */
 
     pub fn resample_along_axis_par(&self, data: &Array2<F>, axis: Axis2D) -> Array2<F> {
         let length = match axis {
@@ -575,21 +555,6 @@ mod tests {
             "2020-09-13T12:26:40+00:00"
         );
     }
-    /*
-    #[test]
-    fn test_interpolate_single() {
-        let (x_0, y_0) = (1., 1.);
-        let (x_1, y_1) = (2., 2.);
-
-        for test_val in [-0.5, 0., 0.5, 1., 2.] {
-            assert_eq!(super::interpolate(test_val, x_0, x_1, y_0, y_1), test_val);
-        }
-
-        assert_eq!(super::interpolate(1000., x_0, x_1, y_0, std::f64::NAN), y_0);
-        assert_eq!(super::interpolate(1000., x_0, x_1, std::f64::NAN, y_1), y_1);
-        assert!(super::interpolate(1000., x_0, x_1, std::f64::NAN, std::f64::NAN).is_nan());
-    }
-    */
 
     #[test]
     fn test_interpolate() {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,4 +1,5 @@
 use core::ops::{Add, Div, Mul, Sub};
+use enterpolation::Generator;
 use ndarray::{Array1, Array2, ArrayView1};
 use ndarray_stats::QuantileExt;
 use num::{Float, Zero};
@@ -60,6 +61,57 @@ pub fn interpolate_between_known<
 ) -> T {
     (known_xy0.1 * (known_xy1.0 - x) + known_xy1.1 * (x - known_xy0.0))
         / (known_xy1.0 - known_xy0.0)
+}
+
+fn interpolate<T: Float + Copy + Sub<Output = T> + std::fmt::Display>(
+    x_new: T,
+    x_old_0: T,
+    x_old_1: T,
+    y_old_0: T,
+    y_old_1: T,
+) -> T {
+    let res = if (!y_old_0.is_finite()) & (!y_old_1.is_finite()) {
+        T::nan()
+    } else {
+        if !y_old_0.is_finite() {
+            y_old_1
+        } else if !y_old_1.is_finite() {
+            y_old_0
+        } else {
+            y_old_0 + (x_new - x_old_0) * (y_old_1 - y_old_0) / (x_old_1 - x_old_0)
+        }
+    };
+    println!("x=[{x_old_0}, {x_old_1}], y=[{y_old_0}, {y_old_1}] => [{x_new}, {res}]");
+    res
+}
+
+fn interpolate_vec<T: Float + Copy + Sub<Output = T> + std::fmt::Debug>(
+    x_old: &[T],
+    y_old: &[T],
+    x_new: &[T],
+) -> Vec<T> {
+    if x_old.len() != y_old.len() {
+        panic!("Interpolation failed. x_old and y_old must have the same length");
+    }
+
+    let model = enterpolation::linear::Linear::builder()
+        .elements(y_old)
+        .knots(x_old)
+        .build()
+        .unwrap();
+    model.sample(x_new.iter().map(|v| v.to_owned())).collect()
+}
+
+fn interpolate_ndarray<T: Float + std::fmt::Debug>(
+    x_old: &ArrayView1<T>,
+    y_old: &ArrayView1<T>,
+    x_new: &ArrayView1<T>,
+) -> Array1<T> {
+    Array1::<T>::from_vec(interpolate_vec(
+        &x_old.to_vec(),
+        &y_old.to_vec(),
+        &x_new.to_vec(),
+    ))
 }
 
 /// Derive the quantiles of an iterator of values
@@ -333,77 +385,17 @@ impl<F: Float + std::fmt::Display + std::iter::Sum + Send + Sync + std::fmt::Deb
         let target_x_values = equally_spaced_from_sparse::<F>(&x_values, resolution);
         Self::_new(x_values, target_x_values, true)
     }
-
-    fn _resample<F2: Float + std::fmt::Display + std::iter::Sum + Send>(
+    fn _resample<F2: Float + std::fmt::Display + std::iter::Sum + Send + std::fmt::Debug>(
         &self,
         x_values: &Array1<F2>,
         target_x_values: &Array1<F2>,
         y_values: &ArrayView1<F2>,
     ) -> Array1<F2> {
-        let mut new_y_values = Vec::<F2>::new();
-        for (i, target_x_value) in target_x_values.iter().enumerate() {
-            let indices_for_slope = &self.slope_indices[i];
-            let indices_for_intercept = &self.intercept_indices[i];
-            let mut x_diffs = Vec::<F2>::new();
-            let mut y_diffs = Vec::<F2>::new();
-            for j in 0..indices_for_slope.len() {
-                for k in 0..indices_for_slope.len() {
-                    if j <= k {
-                        continue;
-                    }
-
-                    let x_diff = x_values[indices_for_slope[k]] - x_values[indices_for_slope[j]];
-                    let y_diff = y_values[indices_for_slope[k]] - y_values[indices_for_slope[j]];
-
-                    if self._debug {
-                        println!("{j} - {k}: y_diff={y_diff}, x_diff={x_diff}");
-                    }
-
-                    if x_diff == Zero::zero() {
-                        continue;
-                    }
-
-                    x_diffs.push(x_diff);
-                    y_diffs.push(y_diff);
-                }
-            }
-            let mean_xdiff = x_diffs.iter().map(|v| v.to_owned()).sum::<F2>();
-            let mean_slope = match mean_xdiff != Zero::zero() {
-                true => y_diffs.iter().map(|v| v.to_owned()).sum::<F2>() / mean_xdiff,
-                false => Zero::zero(),
-            };
-
-            let mut intercepts = Vec::<F2>::new();
-
-            for j in 0..indices_for_intercept.len() {
-                let x_value = x_values[indices_for_intercept[j]];
-                let intercept: F2 =
-                    y_values[indices_for_intercept[j]] - (x_value - *target_x_value) * mean_slope;
-                if self._debug {
-                    println!("Calculating intercept for {x_value} => {intercept}");
-                }
-                intercepts.push(intercept);
-            }
-
-            let mean_intercept: F2 = intercepts.iter().map(|v| v.to_owned()).sum::<F2>()
-                / F2::from(intercepts.len()).unwrap();
-
-            new_y_values.push(mean_intercept);
-
-            if self._debug {
-                println!("{mean_slope} * x + {mean_intercept}");
-            }
-        }
-
-        if self._debug {
-            //let targetx = &self.target_x_values;
-            //println!("New X values: {targetx:?}");
-            //println!("New Y values: {new_y_values:?}");
-        }
-
-        Array1::<F2>::from_vec(new_y_values)
+        interpolate_ndarray::<F2>(&x_values.view(), y_values, &target_x_values.view())
     }
-    pub fn resample_convert<F2: Float + std::fmt::Display + std::iter::Sum + Send>(
+    pub fn resample_convert<
+        F2: Float + std::fmt::Display + std::iter::Sum + Send + std::fmt::Debug,
+    >(
         &self,
         y_values: &ArrayView1<F2>,
     ) -> Array1<F2> {
@@ -416,13 +408,12 @@ impl<F: Float + std::fmt::Display + std::iter::Sum + Send + Sync + std::fmt::Deb
         self._resample(&self.x_values, &self.target_x_values, y_values)
     }
 
-    /*
-    pub fn resample_along_axis(&self, data: &mut Array2<F>, axis: Axis2D) {
+    pub fn resample_along_axis(&self, data: &Array2<F>, axis: Axis2D) -> Array2<F> {
         let nd_axis = match axis {
-            Axis2D::Row => Axis(0),
-            Axis2D::Col => Axis(1),
+            Axis2D::Row => ndarray::Axis(0),
+            Axis2D::Col => ndarray::Axis(1),
         };
-        let slice = Slice::new(0, Some(self.target_x_values.len() as isize), 1);
+        let slice = ndarray::Slice::new(0, Some(self.target_x_values.len() as isize), 1);
 
         let length = match axis {
             Axis2D::Row => data.shape()[0],
@@ -431,21 +422,23 @@ impl<F: Float + std::fmt::Display + std::iter::Sum + Send + Sync + std::fmt::Deb
 
         let mut buffer = Array1::<F>::zeros(length);
 
+        let mut data2 = data.clone();
+
         let axis_values = match axis {
-            Axis2D::Row => data.columns_mut(),
-            Axis2D::Col => data.rows_mut(),
+            Axis2D::Row => data2.columns_mut(),
+            Axis2D::Col => data2.rows_mut(),
         };
 
         for mut arr in axis_values {
             let resampled = self.resample(&arr.view());
 
-            let mut slice = buffer.slice_axis_mut(Axis(0), slice);
+            let mut slice = buffer.slice_axis_mut(ndarray::Axis(0), slice);
             slice.assign(&resampled);
             arr.assign(&buffer);
         }
-        data.slice_axis_inplace(nd_axis, slice);
+        data2.slice_axis_inplace(nd_axis, slice);
+        data2
     }
-    */
 
     pub fn resample_along_axis_par(&self, data: &Array2<F>, axis: Axis2D) -> Array2<F> {
         let length = match axis {
@@ -584,6 +577,70 @@ mod tests {
     }
     /*
     #[test]
+    fn test_interpolate_single() {
+        let (x_0, y_0) = (1., 1.);
+        let (x_1, y_1) = (2., 2.);
+
+        for test_val in [-0.5, 0., 0.5, 1., 2.] {
+            assert_eq!(super::interpolate(test_val, x_0, x_1, y_0, y_1), test_val);
+        }
+
+        assert_eq!(super::interpolate(1000., x_0, x_1, y_0, std::f64::NAN), y_0);
+        assert_eq!(super::interpolate(1000., x_0, x_1, std::f64::NAN, y_1), y_1);
+        assert!(super::interpolate(1000., x_0, x_1, std::f64::NAN, std::f64::NAN).is_nan());
+    }
+    */
+
+    #[test]
+    fn test_interpolate() {
+        let mut tests = Vec::<[Vec<f64>; 4]>::new();
+
+        let x = vec![1.0, 2.0, 3.0];
+        let y = vec![1.0, 2.0, 3.0];
+        let x_new = vec![1.5, 2.5, 0., 4.0]; // Includes values for extrapolation
+        tests.push([x, y, x_new.clone(), x_new.clone()]);
+
+        let x = vec![1.0, 3.0, 5.0];
+        let y = vec![1.0, 3.0, 5.0];
+        let x_new = vec![2.0, 4.0, 0.0, 6.0]; // Includes values for extrapolation
+
+        tests.push([x, y, x_new.clone(), x_new.clone()]);
+
+        let x = vec![0., 2., 5.];
+        let y = vec![0., 4., 1.];
+        let x_new = vec![-1., 0., 1., 2., 3., 4., 5., 6.];
+        let y_test = vec![-2., 0., 2., 4., 3., 2., 1., 0.];
+
+        tests.push([x, y, x_new, y_test]);
+
+        for test_case in tests {
+            let y_new = super::interpolate_vec(&test_case[0], &test_case[1], &test_case[2])
+                .iter()
+                .map(|v| (v * 10_f64).round() / 10.)
+                .collect::<Vec<f64>>();
+            assert_eq!(y_new, test_case[3]);
+
+            let y_new_arr = super::interpolate_ndarray(
+                &Array1::from_vec(test_case[0].clone()).view(),
+                &Array1::from_vec(test_case[1].clone()).view(),
+                &Array1::from_vec(test_case[2].clone()).view(),
+            )
+            .mapv(|v| (v * 10_f64).round() / 10.);
+
+            assert_eq!(y_new_arr, Array1::from_vec(test_case[3].clone()));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "x_old and y_old must have the same length")]
+    fn test_interpolate_panic() {
+        let x = vec![1.0, 2.0, 3.0];
+        let y = vec![1.0, 2.0];
+        let x_new = vec![1.5, 2.5];
+        let _ = super::interpolate_vec(&x, &y, &x_new);
+    }
+    /*
+    #[test]
     fn test_groupby_average() {
         let test_data = Array1::<f32>::range(0., 25., 1.)
             .into_shape((5, 5))
@@ -653,6 +710,7 @@ mod tests {
         let resolution = 1.;
 
         let mut resampler = super::Resampler::<f32>::_new_debug(x_values, resolution);
+        println!("{:?}", resampler.target_x_values);
 
         let new_ys = resampler.resample(&y_values.view());
         let new_ys_f64 = resampler.resample_convert::<f64>(&y_values.mapv(|v| f64::from(v)).view());
@@ -681,6 +739,8 @@ mod tests {
             [50, resampler.target_x_values.len()]
         );
 
+        assert!(resampled_colwise.iter().all(|v| !v.is_nan()));
+
         let y_matrix_manycols =
             ndarray::Array2::from_shape_fn((y_values.len(), 50), |(i, _)| y_values[i]);
         let resampled_rowwise =
@@ -689,5 +749,6 @@ mod tests {
             resampled_rowwise.shape(),
             [resampler.target_x_values.len(), 50]
         );
+        assert!(resampled_rowwise.iter().all(|v| !v.is_nan()));
     }
 }


### PR DESCRIPTION
Fixes #30.

Resampling has long been strange in rsgpr, but this addition fixes the weird resampling artefacts (no test for it, but it's visually good). The problem was the homegrown resampling algorithm that just did not work properly. This PR adds `enterpolation` for the functionality instead, which may also be useful in many other aspects in the future.

For some reason, the topographic correction did not work, so I added a tiny fix that makes it work again for me.