### PR TITLE
Change default processing profile. Add external step file or empty step list support. Update pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,10 @@ repos:
     types_or: [rust, markdown]
     #files: ^(src||tests)/
 
-- repo: https://github.com/lovesegfault/beautysh
-  rev: v6.2.1
-  hooks:
-  - id: beautysh
+# - repo: https://github.com/lovesegfault/beautysh
+#   rev: v6.2.1
+#   hooks:
+#   - id: beautysh
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.13.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.6.0
   hooks:
   #- id: check-yaml  # This doesn't work for me (2023-06-06)
   - id: end-of-file-fixer
@@ -12,7 +12,7 @@ repos:
   - id: sort-simple-yaml
         # Fix common spelling mistakes
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.4
+  rev: v2.2.6
   hooks:
   - id: codespell
     args: []
@@ -25,7 +25,7 @@ repos:
   - id: beautysh
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.9.0
+  rev: v2.13.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']

--- a/flake.nix
+++ b/flake.nix
@@ -7,22 +7,25 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-      rsgpr = import ./default.nix { inherit pkgs; };      
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          rsgpr = import ./default.nix { inherit pkgs; };
 
-      in {
-        devShells.default = import ./shell.nix { inherit pkgs; };
-        defaultPackage = rsgpr;
-        packages = {
-          inherit rsgpr;
-          default = rsgpr;
-        };
-      }
+        in
+        {
+          devShells.default = import ./shell.nix { inherit pkgs; };
+          defaultPackage = rsgpr;
+          packages = {
+            inherit rsgpr;
+            default = rsgpr;
+          };
+        }
 
-    ) // {
+      ) // {
       overlays.default = final: prev: {
-        rsgpr = import ./default.nix {pkgs=final; };
+        rsgpr = import ./default.nix { pkgs = final; };
       };
     };
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::gpr;
+use crate::{gpr, tools};
 /// Functions to handle the command line interface (CLI)
 use clap::Parser;
 use std::{path::PathBuf, time::Duration};
@@ -63,7 +63,7 @@ pub struct Args {
     #[clap(long)]
     show_all_steps: bool,
 
-    /// Processing steps to run.
+    /// Processing steps to run, separated by commas. Can be a filepath to a newline separated step file.
     #[clap(long)]
     steps: Option<String>,
 
@@ -150,7 +150,10 @@ impl Args {
                 false => match self.default {
                     true => gpr::default_processing_profile(),
                     false => match &self.steps {
-                        Some(steps) => steps.split(',').map(|s| s.trim().to_string()).collect(),
+                        Some(steps) => match tools::parse_step_list(steps) {
+                            Ok(s) => s,
+                            Err(e) => return ParsedArgs::Error(e),
+                        },
                         None => {
                             println!("No processing steps specified. Saving raw data.");
                             vec![]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,10 +152,8 @@ impl Args {
                     false => match &self.steps {
                         Some(steps) => steps.split(',').map(|s| s.trim().to_string()).collect(),
                         None => {
-                            return ParsedArgs::Error(
-                                "No steps specified. Choose a profile or what steps to run"
-                                    .to_string(),
-                            )
+                            println!("No processing steps specified. Saving raw data.");
+                            vec![]
                         }
                     },
                 },

--- a/src/gpr.rs
+++ b/src/gpr.rs
@@ -1558,12 +1558,6 @@ pub fn default_processing_profile() -> Vec<String> {
             "normalize_horizontal_magnitudes({})",
             DEFAULT_NORMALIZE_HORIZONTAL_MAGNITUDES_CUTOFF
         ),
-        "unphase".to_string(),
-        "kirchhoff_migration2d".to_string(),
-        format!(
-            "normalize_horizontal_magnitudes({})",
-            DEFAULT_NORMALIZE_HORIZONTAL_MAGNITUDES_CUTOFF
-        ),
         format!("dewow({})", DEFAULT_DEWOW_WINDOW),
         format!("auto_gain({})", DEFAULT_AUTOGAIN_N_BINS),
     ]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -5,7 +5,48 @@ use ndarray_stats::QuantileExt;
 use num::Float;
 use rayon::prelude::*;
 /// Miscellaneous functions that are used in other parts of the program
-use std::str::FromStr;
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+/// Parse a provided step list (or filepath to a step list)
+///
+/// # Arguments
+/// - `steps`: An unformatted list of steps, or a filepath
+///
+/// # Returns
+/// Formatted steps either from the string itself or from the parsed file.
+pub fn parse_step_list(steps: &str) -> Result<Vec<String>, String> {
+    let filepath = Path::new(steps);
+    if filepath.is_file() {
+        match crate::tools::read_text(&filepath.to_path_buf()) {
+            Ok(s) => Ok(s),
+            Err(e) => Err(format!("Tried to read step file but failed: {e:?}")),
+        }
+    } else {
+        Ok(steps.split(',').map(|s| s.trim().to_string()).collect())
+    }
+}
+
+/// Read a text file and return all lines as a vec
+///
+/// # Arguments
+/// - `filepath`: The filepath of the text file
+///
+/// # Returns
+/// Each line as a trimmed String
+pub fn read_text(filepath: &PathBuf) -> Result<Vec<String>, std::io::Error> {
+    let content = std::fs::read_to_string(filepath)?;
+
+    let mut lines = Vec::<String>::new();
+
+    for line in content.lines() {
+        lines.push(line.trim().to_owned());
+    }
+
+    Ok(lines)
+}
 
 /// Interpolate an arbitrary amount of independent values between two known points
 ///


### PR DESCRIPTION
Fixes #14.
Fixes #15.

- The default processing profile is now simpler:
```
zero_corr_max_peak
equidistant_traces
correct_antenna_separation
normalize_horizontal_magnitudes(0.3)
dewow(5)
auto_gain(100)
```
- An external newline-separated step file can now be used instead of specifying them all on the command line:
```bash
rsgpr ... --steps path/to/steps.txt
```
the step file should look something like this:
```
equidistant_traces
correct_antenna_separation
auto_gain(100)
```
- Omitting the "--steps" argument now simply converts the data to NetCDF without processing.
- pre-commit is updated so it actually works (#33). `beautysh` is temporarily disabled as it doesn't seem to work. 
