### PR TITLE
Add `bandpass` and `siglog` filter. Increment to 0.2.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "biquad"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8580925877eb35ab50f987a1c2c193eb46000c8827c871bc3425070f086408cc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -1355,6 +1364,7 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 name = "rsgpr"
 version = "0.1.4"
 dependencies = [
+ "biquad",
  "chrono",
  "clap 4.3.2",
  "enterpolation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,7 +1362,7 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rsgpr"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "biquad",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4.3.2", features = ["derive"] }
 glob = "0.3.1"
 parse_duration = "2.1.1"
 num = "0.4.0"
+biquad = "0.5.0"
 enterpolation = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsgpr"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 readme = "README.md"
 

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,3 +1,4 @@
+use biquad::Biquad;
 use ndarray::Array2;
 use num::Float;
 
@@ -24,9 +25,48 @@ pub fn abslog<T: Float>(data: &mut Array2<T>) {
 
     data.mapv_inplace(|v| (v + minval).log10());
 }
+pub trait ButterworthBandpass<T: Float> {
+    fn butter_coef_norm(
+        low_cutoff: T,
+        high_cutoff: T,
+    ) -> Result<biquad::Coefficients<T>, biquad::Errors>;
+}
+
+impl ButterworthBandpass<f32> for f32 {
+    fn butter_coef_norm(
+        low_cutoff: f32,
+        high_cutoff: f32,
+    ) -> Result<biquad::Coefficients<f32>, biquad::Errors> {
+        let center_frequency = (low_cutoff + high_cutoff) / 2.;
+        let bandwidth = high_cutoff - low_cutoff;
+        let q_factor = center_frequency / bandwidth;
+
+        biquad::Coefficients::from_normalized_params(
+            biquad::Type::BandPass,
+            center_frequency,
+            q_factor,
+        )
+    }
+}
+
+pub fn normalized_bandpass<T: Float + ButterworthBandpass<T>>(
+    data: &mut Array2<T>,
+    low_cutoff: T,
+    high_cutoff: T,
+) -> Result<(), biquad::Errors> {
+    for mut col in data.columns_mut() {
+        let coefs = T::butter_coef_norm(low_cutoff, high_cutoff)?;
+
+        let mut filt = biquad::DirectForm2Transposed::new(coefs);
+
+        col.mapv_inplace(|v| filt.run(v));
+    }
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {
+    use biquad::Biquad;
     use ndarray::Array2;
 
     #[test]
@@ -54,5 +94,44 @@ mod tests {
 
         assert!(new_maxval < 2.1);
         assert!(new_maxval > 1.9);
+    }
+
+    #[test]
+    fn test_bandpass() {
+        use super::ButterworthBandpass;
+        // Generate filter coefficients
+        let coefs = f32::butter_coef_norm(0.05, 0.9).unwrap();
+
+        // let data: Vec<f32> = vec![0.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0, 1000.];
+        let data: Vec<f32> = (0..10000)
+            .map(|v| {
+                if v % 3000 == 0 {
+                    1000.
+                } else if v % 3 == 0 {
+                    0.
+                } else if v % 2 == 0 {
+                    -1.
+                } else {
+                    1.
+                }
+            })
+            .collect();
+        // Create filter instance
+        let mut filt = biquad::DirectForm2Transposed::new(coefs);
+
+        let filtered_data = data.iter().map(|v| filt.run(*v)).collect::<Vec<f32>>();
+        // let filtered_data = super::apply_bandpass_1d(&data, &mut filt);
+
+        assert_eq!(filtered_data.len(), data.len());
+
+        assert!(filtered_data.iter().any(|&x| x != 0.0));
+
+        assert!(
+            filtered_data
+                .iter()
+                .max_by(|x, y| x.partial_cmp(y).unwrap())
+                .unwrap()
+                < &300.
+        );
     }
 }

--- a/src/gpr.rs
+++ b/src/gpr.rs
@@ -529,12 +529,12 @@ impl GPR {
     pub fn bandpass(&mut self, low_cutoff: f32, high_cutoff: f32) -> Result<(), String> {
         let start_time = SystemTime::now();
 
-        if (low_cutoff < 0.) | (low_cutoff > 1.) {
+        if !(0. ..=1.).contains(&low_cutoff) {
             return Err(format!(
                 "Normalized low cutoff needs to be in the range 0-1 (provided: {low_cutoff})"
             ));
         }
-        if (high_cutoff < 0.) | (high_cutoff > 1.) {
+        if !(0. ..=1.).contains(&high_cutoff) {
             return Err(format!(
                 "Normalized high cutoff needs to be in the range 0-1 (provided: {high_cutoff})"
             ));


### PR DESCRIPTION
With this PR, I consider most features that I need to exist. There is much left to do, but this at least marks a milestone large enough to do a minor version bump.

## Bandpass filter
With the `biquad` crate, I finally got a bandpass Butterworth filter to work. It's now specified in relative cutoff frequencies (like [scipy.signal.butter](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.butter.html) when `analog=False`), such as `bandpass(0.1 0.9)". This may need changing later as the relative numbers are dependent on dataset height (n samples), not return time or frequency.

## Siglog filter
I made up a name inspired by `abslog` for #47. See the issue for more information.


Closing #47 .
Closing #1 .