### PR TITLE
Add deflate compression to the data variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,7 +1275,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rsgpr"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "biquad",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,25 +542,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "hdf5-src"
-version = "0.8.1"
+name = "hdf5-metno-src"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01493db39ddc0519cf2a83d620d2c037fee60f4fed724cb72dc23763f1727a8"
+checksum = "956b57b8b4e133bcfbc874a2c9c6d4020e0da420dcfa05aea79091888f2b0763"
 dependencies = [
  "cmake",
  "libz-sys",
 ]
 
 [[package]]
-name = "hdf5-sys"
-version = "0.8.1"
+name = "hdf5-metno-sys"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4842d5980dc311a7c8933c7b45534fdae84df5ae7939a0ae8e449a56d4beb3d2"
+checksum = "1e7be8ee30e5034ee48dd30bc85a2fdde6e1ec0e5e19598409e8e9955eab14af"
 dependencies = [
- "hdf5-src",
+ "hdf5-metno-src",
  "libc",
  "libloading",
  "libz-sys",
+ "parking_lot",
  "pkg-config",
  "regex",
  "serde",
@@ -714,18 +715,18 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -780,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -842,37 +843,39 @@ dependencies = [
 
 [[package]]
 name = "netcdf"
-version = "0.8.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfea96e04fb6c7cc3e58d735dbf9213e30b7e88aac0349feeab66abbcb826acc"
+checksum = "3edbd8b8e273c08e42ec7cc255cb907a16f78db0833b8ad3b6457168d90f3a39"
 dependencies = [
- "bitflags 1.3.2",
- "lazy_static",
+ "bitflags 2.9.0",
+ "libc",
  "ndarray",
  "netcdf-sys",
+ "semver",
 ]
 
 [[package]]
 name = "netcdf-src"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efdec1c75d5b0adad74b499c3d97a3906cedd1a9a0dae02a9b8547baef79ec3"
+checksum = "db385e065fef89907fbc08858dddadf7a0e219b654333e7ce31260641a2238b3"
 dependencies = [
  "cmake",
- "hdf5-sys",
+ "hdf5-metno-sys",
  "libz-sys",
 ]
 
 [[package]]
 name = "netcdf-sys"
-version = "0.5.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dfe2cacf1623a0f51f93d2cfd90386ad40b3daff596f5058ec3037c432c772"
+checksum = "e848a01eaee33a1c3f0b2b2e92f03c7fcface4384c0f7cef00024954f19c7868"
 dependencies = [
  "curl-sys",
- "hdf5-sys",
+ "hdf5-metno-sys",
  "libz-sys",
  "netcdf-src",
+ "parking_lot",
  "semver",
 ]
 
@@ -1243,9 +1246,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1254,13 +1269,13 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rsgpr"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "biquad",
  "chrono",
@@ -1320,9 +1335,9 @@ checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1790,12 +1805,13 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
+ "cfg-if",
  "serde",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsgpr"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 readme = "README.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ image = "0.24.6"  # Write images
 smartcore = "0.3.2"  # (Linear) regression packages
 noisy_float = "0.2.0"  # For inputs to ndarray-stats
 rayon = "1.7.0"  # For parallelization of functions
-netcdf = {version = "0.8.1", features = ["ndarray", "static"]}
+netcdf = {version = "0.10.5", features = ["ndarray", "static"]}
 clap = { version = "4.3.2", features = ["derive"] }
 geomorph = "2.0.2" # UTM zone conversion functions
 utm = "0.1.6"  # More UTM zone conversion functions

--- a/src/io.rs
+++ b/src/io.rs
@@ -308,8 +308,8 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
         )?;
 
         // The default coordinates are distance for x and return time for y
-        data.add_attribute("coordinates", "distance return-time")?;
-        data.add_attribute("unit", "mV")?;
+        data.put_attribute("coordinates", "distance return-time")?;
+        data.put_attribute("unit", "mV")?;
     }
 
     if let Some(topo_data) = &gpr.topo_data {
@@ -323,14 +323,14 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
         )?;
 
         // The default coordinates are distance for x and return time for y
-        data2.add_attribute("coordinates", "distance elevation")?;
-        data2.add_attribute("unit", "mV")?;
+        data2.put_attribute("coordinates", "distance elevation")?;
+        data2.put_attribute("unit", "mV")?;
     };
 
     // Add the distance variable to the x dimension
     let mut ds = file.add_variable::<f32>("distance", &["x"])?;
     ds.put_values(&distance_vec, ..)?;
-    ds.add_attribute("unit", "m")?;
+    ds.put_attribute("unit", "m")?;
 
     // Add the time variable to the x dimension
     let mut time = file.add_variable::<f64>("time", &["x"])?;
@@ -342,7 +342,7 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
             .collect::<Vec<f64>>(),
         ..,
     )?;
-    time.add_attribute("unit", "s")?;
+    time.put_attribute("unit", "s")?;
 
     // Add the easting variable to the x dimension
     let mut easting = file.add_variable::<f64>("easting", &["x"])?;
@@ -354,7 +354,7 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
             .collect::<Vec<f64>>(),
         ..,
     )?;
-    easting.add_attribute("unit", "m")?;
+    easting.put_attribute("unit", "m")?;
 
     // Add the northing variable to the x dimension
     let mut northing = file.add_variable::<f64>("northing", &["x"])?;
@@ -366,7 +366,7 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
             .collect::<Vec<f64>>(),
         ..,
     )?;
-    northing.add_attribute("unit", "m")?;
+    northing.put_attribute("unit", "m")?;
 
     // Add the elevation variable to the x dimension
     let mut elevation = file.add_variable::<f64>("elevation", &["x"])?;
@@ -378,7 +378,7 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
             .collect::<Vec<f64>>(),
         ..,
     )?;
-    elevation.add_attribute("unit", "m a.s.l.")?;
+    elevation.put_attribute("unit", "m a.s.l.")?;
 
     // Add the two-way return time variable to the y dimension
     let return_time_arr = (Array1::range(
@@ -394,13 +394,13 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
     .into_raw_vec();
     let mut return_time = file.add_variable::<f32>("return-time", &["y"])?;
     return_time.put_values(&return_time_arr, ..)?;
-    return_time.add_attribute("unit", "ns")?;
+    return_time.put_attribute("unit", "ns")?;
 
     // Add the depth variable to the y dimension
     let mut depth = file.add_variable::<f32>("depth", &["y"])?;
     depth.put_values(&gpr.depths().into_raw_vec(), ..)?;
 
-    depth.add_attribute("unit", "m")?;
+    depth.put_attribute("unit", "m")?;
 
     Ok(())
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -302,6 +302,9 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
     // Add the data to the file
     {
         let mut data = file.add_variable::<f32>("data", &["y", "x"])?;
+        data.set_compression(5, true)?;
+        data.set_chunking(&[1024, 1024])?;
+
         data.put_values(
             &gpr.data.iter().map(|v| v.to_owned()).collect::<Vec<f32>>(),
             ..,
@@ -317,6 +320,9 @@ pub fn export_netcdf(gpr: &gpr::GPR, nc_filepath: &Path) -> Result<(), Box<dyn s
         let height = topo_data.shape()[0];
         file.add_dimension("y2", height)?;
         let mut data2 = file.add_variable::<f32>("data_topographically_corrected", &["y2", "x"])?;
+        data2.set_compression(5, true)?;
+        data2.set_chunking(&[1024, 1024])?;
+
         data2.put_values(
             &topo_data.iter().map(|v| v.to_owned()).collect::<Vec<f32>>(),
             ..,


### PR DESCRIPTION
A quite simple fix led to a more than halving of the file size! For a test dataset:

Original with data + topo data: 361 Mb
Updated with data + topo data: 147 Mb

I haven't checked the writing speed change but it wasn't noticeable. Considering the massive file size improvements I think it's fair either way.

Closing #50.