### PR TITLE
Update GitHub Actions workflows and add MacOS builds/wheels

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v5
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,0 +1,51 @@
+name: Build Python wheels
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+      python-version:
+        type: string
+        required: true
+
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Use system zlib (MacOS)
+      if: runner.os == 'macOS'
+      run: echo "LIBZ_SYS_STATIC=0" >> $GITHUB_ENV
+
+    - name: Install maturin and pytest
+      run: pip install maturin pytest
+
+    - name: Build wheels
+      run: |
+        maturin build --release --features python --no-default-features
+
+    - name: Install built wheel
+      run: |
+        pip install --force-reinstall --find-links target/wheels ridal
+
+    - name: Smoke test
+      run: |
+        python -c "import ridal; print(ridal.__version__)"
+        python -m pytest
+
+    - name: Upload wheels (CI artifact)
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-${{ inputs.os }}-py${{ inputs.python-version }}
+        path: target/wheels/*.whl

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,14 @@ on:
     - v*
   pull_request:
     branches: [main]
+    paths:
+    - src/**
+    - pyproject.toml
+    - Cargo.toml
+    - Cargo.lock
+    - .github/workflows/python.yml
+    - .github/workflows/python-build.yml
+    - test_ridal_interface.py
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
   build-pr:
     name: Build PR (ubuntu / python 3.12)
     if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/python-build.yml@main
+    uses: ./.github/workflows/python-build.yml
     with:
       os: ubuntu-latest
       python-version: '3.12'
@@ -21,7 +21,7 @@ jobs:
   build-all:
     name: Build all platforms
     if: github.event_name != 'pull_request'
-    uses: ./.github/workflows/python-build.yml@main
+    uses: ./.github/workflows/python-build.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,56 +1,50 @@
-name: Build & publish wheels
+name: Build & publish Python wheels
 
 on:
   push:
+    branches: [main]
     tags:
     - v*
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  build-wheels:
-    name: Wheels on ${{ matrix.os }} / Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
+  build-pr:
+    name: Build PR (ubuntu / python 3.12)
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/python-build.yml@main
+    with:
+      os: ubuntu-latest
+      python-version: '3.12'
+
+  build-all:
+    name: Build all platforms
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/python-build.yml@main
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
     strategy:
-      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
         python-version: ['3.10', '3.11', '3.12', '3.13']
 
+  publish:
+    name: Publish to PyPI
+    needs: build-all
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch'
+
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Download all wheels
+      uses: actions/download-artifact@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        path: wheels
 
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Install maturin and pytest
-      run: pip install maturin pytest
-
-    - name: Build wheels
-      run: |
-        maturin build --release --features python --no-default-features
-
-    - name: Install built wheel
-      run: |
-        pip install --force-reinstall --find-links target/wheels ridal
-
-    - name: Smoke test
-      run: |
-        python -c "import ridal; print(ridal.__version__)"
-        python -m pytest
-
-    - name: Publish to PyPi
+    - name: Publish to PyPI
       env:
         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-        maturin publish --features python --no-default-features --skip-existing
-
-    - name: Upload wheels (CI artifact)
-      uses: actions/upload-artifact@v4
-      with:
-        name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
-        path: target/wheels/*.whl
+        pip install maturin
+        maturin publish --features python --no-default-features --skip-existing --glob "wheels/*.whl"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies (Windows GDAL + PROJ via OSGeo4W)
       if: runner.os == 'Windows'
       id: osgeo4w
-      uses: echoix/setup-OSGeo4W@v0.2.0
+      uses: echoix/setup-OSGeo4W@v0.3.0
       with:
         packages: >-
           gdal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,12 @@ on:
     - v*
   pull_request:
     branches: [main]
+    paths:
+    - src/**
+    - Cargo.toml
+    - Cargo.lock
+    - .github/workflows/rust.yml
+    - .github/workflows/pre-commit.yml
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,7 @@ jobs:
       shell: cmd
       run: |
         CALL "${{ steps.osgeo4w.outputs.root }}\OSGeo4W.bat" gdalinfo --version
+        CALL "${{ steps.osgeo4w.outputs.root }}\OSGeo4W.bat" gdallocationinfo --help > NUL
         CALL "${{ steps.osgeo4w.outputs.root }}\OSGeo4W.bat" ogr2ogr --help > NUL
         CALL "${{ steps.osgeo4w.outputs.root }}\OSGeo4W.bat" proj
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,10 +17,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install gdal proj
 
     - name: Install dependencies (Ubuntu)
       if: runner.os == 'Linux'
@@ -47,6 +52,10 @@ jobs:
 
     - name: Rust toolchain
       uses: dtolnay/rust-toolchain@stable
+
+    - name: Use system zlib (MacOS)
+      if: runner.os == 'macOS'
+      run: echo "LIBZ_SYS_STATIC=0" >> $GITHUB_ENV
 
     - name: Verify CMake (Windows)
       if: runner.os == 'Windows'
@@ -81,6 +90,10 @@ jobs:
       run: |
         CALL "${{ steps.osgeo4w.outputs.root }}\OSGeo4W.bat" "%USERPROFILE%\.cargo\bin\cargo.exe" test  --no-default-features -F cli -- --nocapture
 
+    - name: Test (MacOS)
+      if: runner.os == 'macOS'
+      run: cargo test --no-default-features -F cli -- --nocapture
+
     - name: Dry-run cargo publish
       if: runner.os == 'Linux' && !startsWith(github.ref, 'refs/tags/')
       run: cargo publish --dry-run
@@ -103,7 +116,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Rust toolchain
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,19 @@ jobs:
     - name: Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Cache cargo registry and target
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
     - name: Use system zlib (MacOS)
       if: runner.os == 'macOS'
       run: echo "LIBZ_SYS_STATIC=0" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 img.jpg
 .env
 __pycache__/
+.venv

--- a/src/dem.rs
+++ b/src/dem.rs
@@ -4,44 +4,6 @@ use std::path::Path;
 use crate::coords::Coord;
 use std::io::Write;
 
-fn get_gdal_version() -> Result<String, String> {
-    let child = std::process::Command::new("gdalinfo")
-        .arg("--version")
-        .stderr(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| {
-            if e.to_string().contains("No such file or directory") {
-                format!("GDAL (gdalinfo) cannot be found / is not installed: {e}")
-            } else {
-                format!("Call error when spawning process: {e}")
-            }
-        })?;
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| format!("Call failed: {e}"))?;
-
-    if output.status.success() {
-        let mut version = String::from_utf8_lossy(&output.stdout)
-            .trim()
-            .to_string()
-            .replace("GDAL ", "");
-
-        if let Some((first, _)) = version.split_once(",") {
-            version = first.trim().to_string();
-        }
-        Ok(version)
-    } else if output.stderr.is_empty() {
-        Err("Unknown error getting GDAL version.".to_string())
-    } else {
-        Err(format!(
-            "Error getting GDAL version: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ))
-    }
-}
-
 fn run_gdallocationinfo(
     dem_path: &Path,
     coords_wgs84: &[Coord],
@@ -135,7 +97,6 @@ fn parse_elevations_from_output(
 }
 
 pub fn sample_dem(dem_path: &Path, coords_wgs84: &[Coord]) -> Result<Vec<f32>, String> {
-    get_gdal_version()?;
     if coords_wgs84.is_empty() {
         return Err("Coords vec is empty.".into());
     }
@@ -190,6 +151,45 @@ mod tests {
             ),
         ]
     }
+
+    pub fn get_gdal_version() -> Result<String, String> {
+        let child = std::process::Command::new("gdalinfo")
+            .arg("--version")
+            .stderr(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                if e.to_string().contains("No such file") {
+                    format!("GDAL (gdalinfo) cannot be found / is not installed: {e}")
+                } else {
+                    format!("Call error when spawning process: {e}")
+                }
+            })?;
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| format!("Call failed: {e}"))?;
+
+        if output.status.success() {
+            let mut version = String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .to_string()
+                .replace("GDAL ", "");
+
+            if let Some((first, _)) = version.split_once(",") {
+                version = first.trim().to_string();
+            }
+            Ok(version)
+        } else if output.stderr.is_empty() {
+            Err("Unknown error getting GDAL version.".to_string())
+        } else {
+            Err(format!(
+                "Error getting GDAL version: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+        }
+    }
+
     pub fn supports_interpolation() -> Result<bool, String> {
         use std::io::Write;
         use std::process::{Command, Stdio};
@@ -288,7 +288,7 @@ mod tests {
         assert!(super::sample_dem(&wrong_path, &coords_wgs84)
             .err()
             .unwrap()
-            .contains("No such file or directory"));
+            .contains("No such file"));
     }
 
     #[test]
@@ -312,7 +312,7 @@ mod tests {
         // std::env::set_var("PATH", temp_path);
 
         temp_env::with_vars(vec![("PATH", Option::<&str>::None)], || {
-            if super::get_gdal_version().is_ok() {
+            if get_gdal_version().is_ok() {
                 eprintln!("WARNING: Could not properly unset the GDAL location. Skipping test.");
                 return;
             };

--- a/src/dem.rs
+++ b/src/dem.rs
@@ -159,7 +159,7 @@ mod tests {
             .stdout(std::process::Stdio::piped())
             .spawn()
             .map_err(|e| {
-                if e.to_string().contains("No such file") {
+                if e.to_string().contains("No such file or directory") {
                     format!("GDAL (gdalinfo) cannot be found / is not installed: {e}")
                 } else {
                     format!("Call error when spawning process: {e}")
@@ -288,11 +288,11 @@ mod tests {
         assert!(super::sample_dem(&wrong_path, &coords_wgs84)
             .err()
             .unwrap()
-            .contains("No such file"));
+            .contains("No such file or directory"));
     }
 
     #[test]
-    #[cfg(not(target_os = "windows"))] // Added 2026-02-17 because gdal is hard to install in CI
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[serial_test::serial]
     fn test_no_gdal_failure() {
         let crs = Crs::Utm(UtmCrs {

--- a/src/dem.rs
+++ b/src/dem.rs
@@ -79,11 +79,15 @@ fn parse_elevations_from_output(
     }
 
     if elevations.len() != coords_wgs84.len() {
-        if !output.stderr.is_empty() {
-            return Err(format!(
-                "DEM sampling error: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ));
+        let stderr_str = String::from_utf8_lossy(&output.stderr);
+
+        if !stderr_str.is_empty() {
+            return Err(format!("DEM sampling error: {}", stderr_str));
+        }
+
+        // Empty output but no stderr - gdallocationinfo may have failed silently
+        if elevations.is_empty() {
+            return Err("DEM sampling failed. gdallocationinfo returned no data. Check that GDAL is properly installed and in PATH.".to_string());
         }
 
         return Err(format!(

--- a/src/dem.rs
+++ b/src/dem.rs
@@ -236,7 +236,7 @@ mod tests {
     }
 
     #[test]
-    // #[cfg(not(target_os = "windows"))] // Added 2026-02-17 because gdal is hard to install in CI
+    #[cfg(not(target_os = "windows"))] // Added 2026-04-12 because gdal stopped working properly in CI
     #[serial_test::serial]
     fn test_read_elevations() {
         let coords_elevs = make_test_coords();


### PR DESCRIPTION
- Update actions/checkout from v4/v3 to v6 (fixes #92)
- Add macos-14 to Python wheel matrix (fixes #71)
- Add rust dependency caching (fixes #27)
- Add Python build and pytest run for PRs (not just when building wheels)
- Add LIBZ_SYS_STATIC=0 for MacOS builds (why macos failed before)
- Add path filtering to only run Rust/Python CI when Rust/Python files have changed.
- Update actions/setup-python to v5 in pre-commit
- Remove unnecessary `gdalinfo --version` check (it only checked if it was installed, not the actual version)