### PR TITLE
Initial GSSI reading functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ridal"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "approx",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ridal"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 readme = "README.md"
 description="Speeding up Ground Penetrating Radar (GPR) processing"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A near-term goal of Ridal is to enable easy conversion between formats, such as 
 
 
 Much of the functionality has been inspired from the projects [RGPR](https://github.com/emanuelhuber/RGPR) and [ImpDAR](https://github.com/dlilien/ImpDAR); both of which are more mature projects.
-For example, Ridal currently only works on Malå (.rd3) and pulseEKKO (.dt1) radar formats.
+For example, Ridal currently only works on Malå (.rd3), GSSI (.dzt) and pulseEKKO (.dt1) radar formats.
 For many uses, these will more likely be the tools for you!
 
 ![Image of a glacier radargram](https://raw.githubusercontent.com/erikmannerfelt/ridal/v0.5.0/images/kroppbreen_rgm.webp)

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage {
   cargoLock.lockFile = ./Cargo.lock;
 
   buildNoDefaultFeatures = true;
-  buildFeatures = ["cli"];
+  buildFeatures = [ "cli" ];
 
   nativeBuildInputs = with pkgs; [
     pkg-config

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 pub enum FormatKind {
     Ramac,
     PulseEkko,
+    Gssi,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -64,6 +65,19 @@ pub fn all_formats() -> Vec<FormatInfo> {
                 coordinates: ".gp2",
             },
         },
+        FormatInfo {
+            name: "gssi",
+            description: "GSSI DZT/DZG format",
+            capabilities: FormatCapabilities {
+                read: true,
+                write: false,
+            },
+            files: FormatFiles {
+                header: ".DZT",
+                data: ".DZT",
+                coordinates: ".DZG",
+            },
+        },
     ]
 }
 
@@ -77,7 +91,40 @@ pub fn format_info(kind: FormatKind) -> FormatInfo {
             .into_iter()
             .find(|fmt| fmt.name == "pulseekko")
             .unwrap(),
+        FormatKind::Gssi => all_formats()
+            .into_iter()
+            .find(|fmt| fmt.name == "gssi")
+            .unwrap(),
     }
+}
+
+pub fn find_neighbor_case_insensitive(base: &Path, target_extension: &str) -> Option<PathBuf> {
+    let exact = base.with_extension(target_extension);
+    if exact.is_file() {
+        return Some(exact);
+    }
+
+    let parent = base.parent().unwrap_or_else(|| Path::new("."));
+    let stem = base.file_stem().or_else(|| base.file_name())?.to_str()?;
+    let target_extension = target_extension.trim_start_matches('.');
+
+    std::fs::read_dir(parent)
+        .ok()?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .find(|path| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| s.eq_ignore_ascii_case(stem))
+                && path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case(target_extension))
+        })
+}
+
+fn resolve_sidecar(base: &Path, target_extension: &str) -> PathBuf {
+    find_neighbor_case_insensitive(base, target_extension)
+        .unwrap_or_else(|| base.with_extension(target_extension))
 }
 
 pub fn resolve_input(input: &Path) -> Result<ResolvedInput, String> {
@@ -90,60 +137,90 @@ pub fn resolve_input(input: &Path) -> Result<ResolvedInput, String> {
         Some("rad") => Ok(ResolvedInput {
             input: input.to_path_buf(),
             kind: FormatKind::Ramac,
-            header: input.to_path_buf(),
-            data: input.with_extension("rd3"),
-            coordinates: input.with_extension("cor"),
+            header: resolve_sidecar(input, "rad"),
+            data: resolve_sidecar(input, "rd3"),
+            coordinates: resolve_sidecar(input, "cor"),
         }),
         Some("rd3") | Some("cor") => Ok(ResolvedInput {
             input: input.to_path_buf(),
             kind: FormatKind::Ramac,
-            header: input.with_extension("rad"),
-            data: input.with_extension("rd3"),
-            coordinates: input.with_extension("cor"),
+            header: resolve_sidecar(input, "rad"),
+            data: resolve_sidecar(input, "rd3"),
+            coordinates: resolve_sidecar(input, "cor"),
         }),
         Some("hd") => Ok(ResolvedInput {
             input: input.to_path_buf(),
             kind: FormatKind::PulseEkko,
-            header: input.to_path_buf(),
-            data: input.with_extension("dt1"),
-            coordinates: input.with_extension("gp2"),
+            header: resolve_sidecar(input, "hd"),
+            data: resolve_sidecar(input, "dt1"),
+            coordinates: resolve_sidecar(input, "gp2"),
         }),
         Some("dt1") | Some("gp2") => Ok(ResolvedInput {
             input: input.to_path_buf(),
             kind: FormatKind::PulseEkko,
-            header: input.with_extension("hd"),
-            data: input.with_extension("dt1"),
-            coordinates: input.with_extension("gp2"),
+            header: resolve_sidecar(input, "hd"),
+            data: resolve_sidecar(input, "dt1"),
+            coordinates: resolve_sidecar(input, "gp2"),
+        }),
+        Some("dzt") | Some("dzg") | Some("dzx") => Ok(ResolvedInput {
+            input: input.to_path_buf(),
+            kind: FormatKind::Gssi,
+            header: resolve_sidecar(input, "dzt"),
+            data: resolve_sidecar(input, "dzt"),
+            coordinates: resolve_sidecar(input, "dzg"),
         }),
         Some(other) => Err(format!(
-            "Unsupported input extension '.{other}' for {:?}. Supported formats are RAMAC (.rad/.rd3/.cor) and pulseEKKO (.hd/.dt1/.gp2).",
+            "Unsupported input extension '.{other}' for {:?}. Supported formats are RAMAC (.rad/.rd3/.cor), pulseEKKO (.hd/.dt1/.gp2), and GSSI (.dzt/.dzg/.dzx).",
             input
         )),
         None => {
-            let ramac = input.with_extension("rad");
-            let pulseekko = input.with_extension("hd");
-            match (ramac.is_file(), pulseekko.is_file()) {
-                (true, false) => Ok(ResolvedInput {
+            let ramac = find_neighbor_case_insensitive(input, "rad");
+            let pulseekko = find_neighbor_case_insensitive(input, "hd");
+            let gssi = find_neighbor_case_insensitive(input, "dzt");
+            match (ramac, pulseekko, gssi) {
+                (Some(ramac), None, None) => Ok(ResolvedInput {
                     input: input.to_path_buf(),
                     kind: FormatKind::Ramac,
                     header: ramac.clone(),
-                    data: ramac.with_extension("rd3"),
-                    coordinates: ramac.with_extension("cor"),
+                    data: resolve_sidecar(&ramac, "rd3"),
+                    coordinates: resolve_sidecar(&ramac, "cor"),
                 }),
-                (false, true) => Ok(ResolvedInput {
+                (None, Some(pulseekko), None) => Ok(ResolvedInput {
                     input: input.to_path_buf(),
                     kind: FormatKind::PulseEkko,
                     header: pulseekko.clone(),
-                    data: pulseekko.with_extension("dt1"),
-                    coordinates: pulseekko.with_extension("gp2"),
+                    data: resolve_sidecar(&pulseekko, "dt1"),
+                    coordinates: resolve_sidecar(&pulseekko, "gp2"),
                 }),
-                (true, true) => Err(format!(
+                (None, None, Some(gssi)) => Ok(ResolvedInput {
+                    input: input.to_path_buf(),
+                    kind: FormatKind::Gssi,
+                    header: gssi.clone(),
+                    data: gssi.clone(),
+                    coordinates: resolve_sidecar(&gssi, "dzg"),
+                }),
+                (Some(ramac), Some(pulseekko), None) => Err(format!(
                     "Ambiguous extension-less input {:?}: both {:?} and {:?} exist.",
                     input, ramac, pulseekko
                 )),
-                (false, false) => Err(format!(
-                    "Could not infer format for extension-less input {:?}. Tried {:?} and {:?}.",
-                    input, ramac, pulseekko
+                (Some(ramac), None, Some(gssi)) => Err(format!(
+                    "Ambiguous extension-less input {:?}: both {:?} and {:?} exist.",
+                    input, ramac, gssi
+                )),
+                (None, Some(pulseekko), Some(gssi)) => Err(format!(
+                    "Ambiguous extension-less input {:?}: both {:?} and {:?} exist.",
+                    input, pulseekko, gssi
+                )),
+                (Some(ramac), Some(pulseekko), Some(gssi)) => Err(format!(
+                    "Ambiguous extension-less input {:?}: {:?}, {:?}, and {:?} exist.",
+                    input, ramac, pulseekko, gssi
+                )),
+                (None, None, None) => Err(format!(
+                    "Could not infer format for extension-less input {:?}. Tried {:?}, {:?}, and {:?}.",
+                    input,
+                    input.with_extension("rad"),
+                    input.with_extension("hd"),
+                    input.with_extension("dzt")
                 )),
             }
         }
@@ -160,7 +237,14 @@ mod tests {
             .into_iter()
             .map(|fmt| fmt.name.to_string())
             .collect::<Vec<String>>();
-        assert_eq!(names, vec!["ramac".to_string(), "pulseekko".to_string()]);
+        assert_eq!(
+            names,
+            vec![
+                "ramac".to_string(),
+                "pulseekko".to_string(),
+                "gssi".to_string()
+            ]
+        );
     }
 
     #[test]
@@ -185,5 +269,44 @@ mod tests {
         let resolved = resolve_input(Path::new("line01.dt1")).unwrap();
         assert_eq!(resolved.kind, FormatKind::PulseEkko);
         assert_eq!(resolved.header, PathBuf::from("line01.hd"));
+    }
+
+    #[test]
+    fn test_resolve_gssi_extensions() {
+        let resolved = resolve_input(Path::new("line01.dzt")).unwrap();
+        assert_eq!(resolved.kind, FormatKind::Gssi);
+        assert_eq!(resolved.data, PathBuf::from("line01.dzt"));
+        assert_eq!(resolved.coordinates, PathBuf::from("line01.dzg"));
+
+        let resolved = resolve_input(Path::new("line01.dzg")).unwrap();
+        assert_eq!(resolved.kind, FormatKind::Gssi);
+        assert_eq!(resolved.header, PathBuf::from("line01.dzt"));
+    }
+
+    #[test]
+    fn test_resolve_case_insensitive_sidecars() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let rad = temp_dir.path().join("LINE01.RAD");
+        let rd3 = temp_dir.path().join("LINE01.RD3");
+        let cor = temp_dir.path().join("LINE01.COR");
+        std::fs::write(&rad, "").unwrap();
+        std::fs::write(&rd3, "").unwrap();
+        std::fs::write(&cor, "").unwrap();
+
+        let resolved = resolve_input(&temp_dir.path().join("LINE01")).unwrap();
+        assert_eq!(resolved.kind, FormatKind::Ramac);
+        assert_eq!(resolved.header, rad);
+        assert_eq!(resolved.data, rd3);
+        assert_eq!(resolved.coordinates, cor);
+
+        let dzt = temp_dir.path().join("TRACK.DZT");
+        let dzg = temp_dir.path().join("TRACK.DZG");
+        std::fs::write(&dzt, "").unwrap();
+        std::fs::write(&dzg, "").unwrap();
+
+        let resolved = resolve_input(&temp_dir.path().join("TRACK")).unwrap();
+        assert_eq!(resolved.kind, FormatKind::Gssi);
+        assert_eq!(resolved.header, dzt);
+        assert_eq!(resolved.coordinates, dzg);
     }
 }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -99,11 +99,6 @@ pub fn format_info(kind: FormatKind) -> FormatInfo {
 }
 
 pub fn find_neighbor_case_insensitive(base: &Path, target_extension: &str) -> Option<PathBuf> {
-    let exact = base.with_extension(target_extension);
-    if exact.is_file() {
-        return Some(exact);
-    }
-
     let parent = base.parent().unwrap_or_else(|| Path::new("."));
     let stem = base.file_stem().or_else(|| base.file_name())?.to_str()?;
     let target_extension = target_extension.trim_start_matches('.');

--- a/src/gpr.rs
+++ b/src/gpr.rs
@@ -55,7 +55,9 @@ impl GPRMeta {
     /// # Arguments
     /// - `projected_crs`: The CRS to project coordinates into
     pub fn find_cor(&self, projected_crs: Option<&String>) -> Result<GPRLocation, Box<dyn Error>> {
-        io::load_cor(&self.data_filepath.with_extension("cor"), projected_crs)
+        let cor = crate::formats::find_neighbor_case_insensitive(&self.data_filepath, "cor")
+            .unwrap_or_else(|| self.data_filepath.with_extension("cor"));
+        io::load_cor(&cor, projected_crs)
     }
 }
 
@@ -740,14 +742,18 @@ impl GPR {
         metadata: GPRMeta,
     ) -> Result<GPR, Box<dyn Error>> {
         let data = match metadata.data_filepath.extension().and_then(|s| s.to_str()) {
-            Some("rd3") => Ok(io::load_rd3(
+            Some(ext) if ext.eq_ignore_ascii_case("rd3") => Ok(io::load_rd3(
                 &metadata.data_filepath,
                 metadata.samples as usize,
             )?),
-            Some("dt1") => Ok(io::load_pe_dt1(
+            Some(ext) if ext.eq_ignore_ascii_case("dt1") => Ok(io::load_pe_dt1(
                 &metadata.data_filepath,
                 metadata.samples as usize,
                 metadata.last_trace as usize,
+            )?),
+            Some(ext) if ext.eq_ignore_ascii_case("dzt") => Ok(io::load_dzt(
+                &metadata.data_filepath,
+                metadata.samples as usize,
             )?),
             _ => Err(format!("Unknown filetype: {:?}", metadata.data_filepath)),
         }?;
@@ -1817,6 +1823,17 @@ fn load_meta_and_location(
             let location = io::load_pe_gp2(&resolved.coordinates, crs)?;
             (meta, location)
         }
+        FormatKind::Gssi => {
+            if cor_path.is_some() {
+                return Err("The --cor option is only supported for RAMAC inputs.".into());
+            }
+            if !resolved.header.is_file() {
+                return Err(format!("File not found: {:?}", resolved.header).into());
+            }
+            let meta = io::load_gssi_dzt(&resolved.header, medium_velocity, override_antenna_mhz)?;
+            let location = io::load_gssi_dzg(&resolved.coordinates, crs)?;
+            (meta, location)
+        }
     };
 
     if let Some(dem_path) = dem_path {
@@ -2201,6 +2218,16 @@ fn load_single_gpr_for_grouping(
                 },
             )?
         }
+        FormatKind::Gssi => {
+            io::load_gssi_dzt(&resolved.header, medium_velocity, override_antenna_mhz).map_err(
+                |e| {
+                    format!(
+                        "Failed to load GSSI header '{}': {e}",
+                        resolved.header.display()
+                    )
+                },
+            )?
+        }
     };
 
     let mut location = if let Some(cor_override) = &cor_path {
@@ -2222,6 +2249,11 @@ fn load_single_gpr_for_grouping(
                 let gp2 = &resolved.coordinates;
                 io::load_pe_gp2(gp2, crs.as_ref())
                     .map_err(|e| format!("Failed to load .gp2 '{}': {e}", gp2.display()))?
+            }
+            FormatKind::Gssi => {
+                let dzg = &resolved.coordinates;
+                io::load_gssi_dzg(dzg, crs.as_ref())
+                    .map_err(|e| format!("Failed to load .dzg '{}': {e}", dzg.display()))?
             }
         }
     };

--- a/src/io.rs
+++ b/src/io.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 
 use crate::export::ExportAttr;
-use crate::{gpr, tools};
+use crate::{formats, gpr, tools};
 
 /// Load and parse a Malå metadata file (.rad)
 ///
@@ -33,7 +33,8 @@ pub fn load_rad(
     // Collect all rows into a hashmap, assuming a "KEY:VALUE" structure.
     let data: HashMap<&str, &str> = content.lines().filter_map(|s| s.split_once(':')).collect();
 
-    let rd3_filepath = filepath.with_extension("rd3");
+    let rd3_filepath = formats::find_neighbor_case_insensitive(filepath, "rd3")
+        .unwrap_or_else(|| filepath.with_extension("rd3"));
     if !rd3_filepath.is_file() {
         return Err(format!("File not found: {rd3_filepath:?}").into());
     };
@@ -322,7 +323,8 @@ pub fn load_pe_hd(
 
     let frequency = 1000. * (samples as f32) / time_window;
 
-    let dt1_filepath = filepath.with_extension("dt1");
+    let dt1_filepath = formats::find_neighbor_case_insensitive(filepath, "dt1")
+        .unwrap_or_else(|| filepath.with_extension("dt1"));
     if !dt1_filepath.is_file() {
         return Err(format!("File not found: {dt1_filepath:?}").into());
     };
@@ -368,6 +370,259 @@ pub fn load_pe_hd(
             .parse()?,
         data_filepath: dt1_filepath,
         medium_velocity,
+    })
+}
+
+fn gssi_date_to_iso(date: &str) -> Result<String, Box<dyn Error>> {
+    if date.len() != 6 {
+        return Err(format!("Invalid GSSI date: {date}").into());
+    }
+
+    let day = &date[0..2];
+    let month = &date[2..4];
+    let year = &date[4..6];
+    let year = format!("20{year}");
+    Ok(format!("{year}-{month}-{day}"))
+}
+
+fn read_gssi_header(
+    bytes: &[u8],
+) -> Result<(u16, u16, u16, f32, f32, f32, f32, u16, String), Box<dyn Error>> {
+    if bytes.len() < 128 {
+        return Err("GSSI header is too short".into());
+    }
+
+    let u16_at = |offset: usize| u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap());
+    let i16_at = |offset: usize| i16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap());
+    let f32_at = |offset: usize| f32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap());
+
+    let data = u16_at(2);
+    let nsamp = u16_at(4);
+    let bits = u16_at(6);
+    let _zero = i16_at(8);
+    let sps = f32_at(10);
+    let spm = f32_at(14);
+    let _mpm = f32_at(18);
+    let position = f32_at(22);
+    let range = f32_at(26);
+    let _npass = u16_at(30);
+    let _create = &bytes[32..36];
+    let _modify = &bytes[36..40];
+    let _rgain = u16_at(40);
+    let _nrgain = u16_at(42);
+    let _text = u16_at(44);
+    let _ntext = u16_at(46);
+    let _proc = u16_at(48);
+    let _nproc = u16_at(50);
+    let nchan = u16_at(52);
+    let antname = String::from_utf8_lossy(&bytes[98..112])
+        .trim_matches('\0')
+        .trim()
+        .to_string();
+
+    Ok((data, nsamp, bits, sps, spm, position, range, nchan, antname))
+}
+
+fn gssi_data_offset(bytes: &[u8], bits: u16, data: u16, nchan: u16) -> usize {
+    let bytes_per_sample = (bits as usize / 8).max(1);
+    let offset = if data < 1024 {
+        1024 * data as usize
+    } else {
+        1024 * nchan as usize
+    };
+    if offset < bytes.len() {
+        offset
+    } else {
+        32768 * bytes_per_sample
+    }
+}
+
+fn gssi_bits_to_millivolt(bits: u16) -> f32 {
+    // RGPR's readDZT.R uses bits2volt(Vmax = 50, nbits = bits), i.e.
+    // abs(Vmax - Vmin) / 2^nbits with Vmin = -Vmax, then ridal exports mV.
+    100000.0 / 2f32.powi(bits as i32)
+}
+
+pub(crate) fn gssi_antenna_mhz(antname: &str) -> Option<f32> {
+    // RGPR readDZT.R antenna map.
+    match antname.trim() {
+        "3200" | "3200MLF" => None,
+        "500MHz" => Some(500.),
+        "3207" | "3207AP" => Some(100.),
+        "5106" | "5106A" | "50200HS" => Some(200.),
+        "50300" => Some(300.),
+        "350" | "350HS" => Some(350.),
+        "50270" | "50270S" => Some(270.),
+        "50400" | "50400S" => Some(400.),
+        "800" | "D50800" => Some(800.),
+        "3101" | "3101A" => Some(900.),
+        "51600" | "51600S" => Some(1600.),
+        "62000" | "62000-003" => Some(2000.),
+        "62300" | "62300XT" => Some(2300.),
+        "52600" | "52600S" => Some(2600.),
+        other => other
+            .split_whitespace()
+            .next()
+            .and_then(|token| token.trim_end_matches("MHz").parse::<f32>().ok()),
+    }
+}
+
+pub fn load_gssi_dzt(
+    filepath: &Path,
+    medium_velocity: f32,
+    override_antenna_mhz: Option<f32>,
+) -> Result<gpr::GPRMeta, Box<dyn Error>> {
+    let bytes = std::fs::read(filepath)?;
+    let (data, nsamp, bits, sps, _spm, position, range, nchan, antenna) = read_gssi_header(&bytes)?;
+    let time_window = range - position;
+    let frequency = 1000. * (nsamp as f32) / time_window;
+    let antenna_mhz = match override_antenna_mhz {
+        Some(v) => v,
+        None => gssi_antenna_mhz(&antenna).ok_or_else(|| {
+            format!(
+                "Could not read frequency from the GSSI antenna field ({antenna:?}). Try using the antenna MHz override"
+            )
+        })?,
+    };
+
+    let data_offset = gssi_data_offset(&bytes, bits, data, nchan);
+    if data_offset >= bytes.len() {
+        return Err(format!("File too short: no data found in {:?}", filepath).into());
+    }
+    let bytes_per_sample = (bits as usize / 8).max(1);
+    let samples_per_trace = nsamp as usize;
+    let bytes_per_trace = samples_per_trace * bytes_per_sample;
+    if bytes_per_trace == 0 {
+        return Err("Invalid GSSI header: zero sample size".into());
+    }
+    let trace_bytes = bytes.len() - data_offset;
+    let last_trace = (trace_bytes / bytes_per_trace) as u32;
+
+    Ok(gpr::GPRMeta {
+        samples: nsamp as u32,
+        frequency,
+        frequency_steps: 0,
+        time_interval: 1.0 / sps,
+        antenna_mhz,
+        antenna,
+        antenna_separation: 0.0,
+        time_window,
+        last_trace,
+        data_filepath: filepath.to_path_buf(),
+        medium_velocity,
+    })
+}
+
+pub fn load_dzt(filepath: &Path, height: usize) -> Result<Array2<f32>, Box<dyn Error>> {
+    let bytes = std::fs::read(filepath)?;
+    let (data, nsamp, bits, _sps, _spm, _position, _range, nchan, _antenna) =
+        read_gssi_header(&bytes)?;
+    let data_offset = gssi_data_offset(&bytes, bits, data, nchan);
+    if data_offset >= bytes.len() {
+        return Err(format!("File too short: no data found in {:?}", filepath).into());
+    }
+
+    let bytes_per_sample = (bits as usize / 8).max(1);
+    let samples_per_trace = height.max(nsamp as usize);
+    let bytes_per_trace = samples_per_trace * bytes_per_sample;
+    let payload = &bytes[data_offset..];
+    if payload.len() < bytes_per_trace {
+        return Err(format!("File too short: {:?}", filepath).into());
+    }
+
+    let mut data: Vec<f32> = Vec::with_capacity(payload.len() / bytes_per_sample);
+    let scale = gssi_bits_to_millivolt(bits);
+    match bits {
+        8 => {
+            for byte in payload.iter() {
+                data.push((*byte as i16 - 128) as f32 * scale);
+            }
+        }
+        16 => {
+            for chunk in payload.chunks_exact(2) {
+                let value = u16::from_le_bytes([chunk[0], chunk[1]]) as i32 - 32768;
+                data.push(value as f32 * scale);
+            }
+        }
+        32 => {
+            for chunk in payload.chunks_exact(4) {
+                let value = i32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                data.push(value as f32 * scale);
+            }
+        }
+        other => return Err(format!("Unsupported GSSI sample width: {other} bits").into()),
+    }
+
+    let width = data.len() / height;
+    Ok(Array2::from_shape_vec((width, height), data)?.reversed_axes())
+}
+
+pub fn load_gssi_dzg(
+    filepath: &Path,
+    projected_crs: Option<&String>,
+) -> Result<gpr::GPRLocation, Box<dyn Error>> {
+    let content = std::fs::read_to_string(filepath)?;
+    let mut date_str: Option<String> = None;
+    let mut current_scan: Option<u32> = None;
+    let mut coords = Vec::<crate::coords::Coord>::new();
+    let mut points: Vec<gpr::CorPoint> = Vec::new();
+
+    for line in content.lines() {
+        let parts: Vec<&str> = line.split(',').collect();
+        match parts.first().copied() {
+            Some("$GSSIS") => {
+                current_scan = parts.get(1).and_then(|s| s.parse::<u32>().ok());
+            }
+            Some("$GPRMC") => {
+                if let Some(date) = parts.get(9) {
+                    date_str = Some(gssi_date_to_iso(date)?);
+                }
+            }
+            Some("$GPGGA") => {
+                let Some(scan) = current_scan else {
+                    continue;
+                };
+                let Some(date) = &date_str else {
+                    continue;
+                };
+                let (datetime, coord, altitude) = read_gga(line, date)?;
+                coords.push(coord);
+                points.push(gpr::CorPoint {
+                    trace_n: scan,
+                    time_seconds: datetime,
+                    easting: 0.,
+                    northing: 0.,
+                    altitude,
+                });
+                current_scan = None;
+            }
+            _ => {}
+        }
+    }
+
+    if points.is_empty() {
+        return Err(format!("Could not parse location data from: {:?}", filepath).into());
+    }
+
+    let projected_crs = match projected_crs {
+        Some(s) => s.to_string(),
+        None => crate::coords::UtmCrs::optimal_crs(&coords[0]).to_epsg_str(),
+    };
+    for (i, coord) in crate::coords::from_wgs84(
+        &coords,
+        &crate::coords::Crs::from_user_input(&projected_crs)?,
+    )?
+    .iter()
+    .enumerate()
+    {
+        points[i].easting = coord.x;
+        points[i].northing = coord.y;
+    }
+
+    Ok(gpr::GPRLocation {
+        cor_points: points,
+        correction: gpr::LocationCorrection::None,
+        crs: projected_crs.to_string(),
     })
 }
 
@@ -831,7 +1086,43 @@ mod tests {
 
     use std::{path::PathBuf, str::FromStr};
 
-    use super::{load_cor, load_rad};
+    use super::{gssi_antenna_mhz, load_cor, load_dzt, load_gssi_dzg, load_gssi_dzt, load_rad};
+
+    fn make_gssi_dzt(bytes_per_sample: usize) -> Vec<u8> {
+        let samples = 4usize;
+        let traces = 2usize;
+        let data_offset = 128 * 1024;
+        let mut bytes = vec![0u8; data_offset + samples * traces * bytes_per_sample];
+        bytes[2..4].copy_from_slice(&128u16.to_le_bytes());
+        bytes[4..6].copy_from_slice(&(samples as u16).to_le_bytes());
+        bytes[6..8].copy_from_slice(&((bytes_per_sample * 8) as u16).to_le_bytes());
+        bytes[10..14].copy_from_slice(&12f32.to_le_bytes());
+        bytes[14..18].copy_from_slice(&4f32.to_le_bytes());
+        bytes[22..26].copy_from_slice(&(-60f32).to_le_bytes());
+        bytes[26..30].copy_from_slice(&600f32.to_le_bytes());
+        bytes[52..54].copy_from_slice(&1u16.to_le_bytes());
+        let ant = b"5106";
+        bytes[98..98 + ant.len()].copy_from_slice(ant);
+
+        let mut offset = data_offset;
+        for trace in 0..traces {
+            for sample in 0..samples {
+                let value = (trace * 10 + sample + 1) as i32;
+                bytes[offset..offset + bytes_per_sample]
+                    .copy_from_slice(&value.to_le_bytes()[..bytes_per_sample]);
+                offset += bytes_per_sample;
+            }
+        }
+
+        bytes
+    }
+
+    #[test]
+    fn test_gssi_antenna_map() {
+        assert_eq!(gssi_antenna_mhz("5106"), Some(200.));
+        assert_eq!(gssi_antenna_mhz("3101A"), Some(900.));
+        assert_eq!(gssi_antenna_mhz("50300"), Some(300.));
+    }
 
     /// Fake some data. One point is in the northern hemisphere and one is in the southern
     fn fake_cor_text() -> String {
@@ -1079,6 +1370,49 @@ mod tests {
 
         assert_eq!(locations.cor_points.len(), 9);
         assert!(locations.cor_points.first().unwrap().northing > 77.);
+    }
+
+    #[test]
+    fn test_load_gssi_dzt() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dzt_path = temp_dir.path().join("track.DZT");
+        std::fs::write(&dzt_path, make_gssi_dzt(4)).unwrap();
+
+        let meta = load_gssi_dzt(&dzt_path, 0.1, Some(200.)).unwrap();
+        assert_eq!(meta.samples, 4);
+        assert_eq!(meta.last_trace, 2);
+        assert_eq!(meta.time_interval, 1.0 / 12.0);
+        assert_eq!(meta.antenna_mhz, 200.);
+        assert_eq!(meta.antenna, "5106");
+
+        let data = load_dzt(&dzt_path, 4).unwrap();
+        assert_eq!(data.shape(), &[4, 2]);
+        assert!(data[[0, 0]] > 0.0);
+        assert!(data[[0, 1]] > 0.0);
+        assert!(data[[0, 0]] < 1.0);
+        assert!(data[[0, 1]] < 1.0);
+    }
+
+    #[test]
+    fn test_load_gssi_dzg() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dzg_path = temp_dir.path().join("track.DZG");
+        let dzg_text = [
+            "$GSSIS,0,-1",
+            "$GPRMC,140541,A,7901.4763,N,01332.0122,E,0.0,357.5,140424,8.8,E,A*16",
+            "$GPGGA,140541,7901.4763,N,01332.0122,E,1,12,0.7,753.0,M,35.3,M,,*4C",
+            "$GSSIS,3,-1",
+            "$GPRMC,140543,A,7901.4764,N,01332.0123,E,0.0,357.5,140424,8.8,E,A*15",
+            "$GPGGA,140543,7901.4764,N,01332.0123,E,1,12,0.7,752.9,M,35.3,M,,*4F",
+        ]
+        .join("\n");
+        std::fs::write(&dzg_path, dzg_text).unwrap();
+
+        let locations = load_gssi_dzg(&dzg_path, Some(&"EPSG:4326".to_string())).unwrap();
+        assert_eq!(locations.cor_points.len(), 2);
+        assert_eq!(locations.cor_points[0].trace_n, 0);
+        assert_eq!(locations.cor_points[1].trace_n, 3);
+        assert!((locations.cor_points[0].altitude - 753.0).abs() < 1e-6);
     }
 
     #[test]

--- a/src/io.rs
+++ b/src/io.rs
@@ -385,9 +385,9 @@ fn gssi_date_to_iso(date: &str) -> Result<String, Box<dyn Error>> {
     Ok(format!("{year}-{month}-{day}"))
 }
 
-fn read_gssi_header(
-    bytes: &[u8],
-) -> Result<(u16, u16, u16, f32, f32, f32, f32, u16, String), Box<dyn Error>> {
+type GssiHeader = (u16, u16, u16, f32, f32, f32, f32, u16, String);
+
+fn read_gssi_header(bytes: &[u8]) -> Result<GssiHeader, Box<dyn Error>> {
     if bytes.len() < 128 {
         return Err("GSSI header is too short".into());
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -340,8 +340,8 @@ impl<F: Float + std::fmt::Display + std::iter::Sum + Send + Sync + std::fmt::Deb
             }
 
             if indices_between.len() < 2 {
-                potential_outside_behind.sort_by(|a, b| a.0.cmp(&b.0));
-                potential_outside_ahead.sort_by(|a, b| a.0.cmp(&b.0));
+                potential_outside_behind.sort_by_key(|a| a.0);
+                potential_outside_ahead.sort_by_key(|a| a.0);
 
                 if let Some(point_behind) = potential_outside_behind.first() {
                     for index in potential_outside_behind


### PR DESCRIPTION
This PR adds GSSI format support. It's still in early stages and may need patching.

It borrows from:

- https://github.com/emanuelhuber/RGPR/blob/master/R/readDZT.R
- https://github.com/NSGeophysics/GPRPy/blob/master/gprpy/toolbox/gprIO_DZT.py
- https://github.com/dlilien/ImpDAR/blob/main/src/impdar/lib/load/load_gssi.py

Another required change was to make neighboring file matching suffix-case-insensitive. For example, a `DAT_0001_A1.RAD` and  `DAT_0001_A1.COR` will now parse successfully (it didn't before).